### PR TITLE
Intitial review

### DIFF
--- a/AnnouncementsBlockPlugin.inc.php
+++ b/AnnouncementsBlockPlugin.inc.php
@@ -26,7 +26,6 @@ class AnnouncementsBlockPlugin extends BlockPlugin
 		$templateMgr->assign('announcementsSidebar', $announcements->toArray());
 		$templateMgr->assign('truncateNum', ctype_digit($this->getSetting($context->getId(), 'truncateNum')) ? intval($this->getSetting($context->getId(), 'truncateNum')) : null);
 		$templateMgr->assign('textAlign', $this->getSetting($context->getId(), 'textAlign') ? $this->getSetting($context->getId(), 'textAlign') : 'justify');
-		$templateMgr->assign('headlineSize', $this->getSetting($context->getId(), 'headlineSize') ? $this->getSetting($context->getId(), 'headlineSize') : 'h2');
 		return parent::getContents($templateMgr, $request);
 	}
 
@@ -67,12 +66,6 @@ class AnnouncementsBlockPlugin extends BlockPlugin
 		switch ($request->getUserVar('verb')) {
 			case 'settings':
 				$templateMgr = TemplateManager::getManager($request);
-				$templateMgr->assign('headlineSizeOptions', [
-					'h2' => 'plugins.blocks.announcements.settings.h2',
-					'h3' => 'plugins.blocks.announcements.settings.h3',
-					'h4' => 'plugins.blocks.announcements.settings.h4',
-					'h5' => 'plugins.blocks.announcements.settings.h5'
-				]);
 				$templateMgr->assign('textAlignOptions', [
 					'left' => 'plugins.blocks.announcements.settings.left',
 					'right' => 'plugins.blocks.announcements.settings.right',

--- a/AnnouncementsBlockPluginSettingsForm.inc.php
+++ b/AnnouncementsBlockPluginSettingsForm.inc.php
@@ -28,7 +28,6 @@ class AnnouncementsBlockPluginSettingsForm extends Form
 		$this->setData('announcementsAmount', $this->plugin->getSetting($contextId, 'announcementsAmount') == null ? 2 : $this->plugin->getSetting($contextId, 'announcementsAmount'));
 		$this->setData('truncateNum', $this->plugin->getSetting($contextId, 'truncateNum'));
 		$this->setData('textAlign', $this->plugin->getSetting($contextId, 'textAlign') == null ? 'right' : $this->plugin->getSetting($contextId, 'textAlign'));
-		$this->setData('headlineSize', $this->plugin->getSetting($contextId, 'headlineSize') == null ? "h2" : $this->plugin->getSetting($contextId, 'headlineSize'));
 		parent::initData();
 	}
 
@@ -37,7 +36,7 @@ class AnnouncementsBlockPluginSettingsForm extends Form
 	 */
 	public function readInputData()
 	{
-		$this->readUserVars(['announcementsAmount', 'truncateNum', 'textAlign', 'headlineSize']);
+		$this->readUserVars(['announcementsAmount', 'truncateNum', 'textAlign']);
 		parent::readInputData();
 	}
 
@@ -64,7 +63,6 @@ class AnnouncementsBlockPluginSettingsForm extends Form
 		$this->plugin->updateSetting($contextId, 'announcementsAmount', $this->getData('announcementsAmount'));
 		$this->plugin->updateSetting($contextId, 'truncateNum', $this->getData('truncateNum'));
 		$this->plugin->updateSetting($contextId, 'textAlign', $this->getData('textAlign'));
-		$this->plugin->updateSetting($contextId, 'headlineSize', $this->getData('headlineSize'));
 		import('classes.notification.NotificationManager');
 		$notificationMgr = new NotificationManager();
 		$notificationMgr->createTrivialNotification(

--- a/locale/de_DE/locale.xml
+++ b/locale/de_DE/locale.xml
@@ -12,8 +12,4 @@
     <message key="plugins.blocks.announcements.settings.right">Rechtsbündig</message>
     <message key="plugins.blocks.announcements.settings.center">Zentriert</message>
     <message key="plugins.blocks.announcements.settings.justify">Blocksatz</message>
-    <message key="plugins.blocks.announcements.settings.h2">H2</message>
-    <message key="plugins.blocks.announcements.settings.h3">H3</message>
-    <message key="plugins.blocks.announcements.settings.h4">H4</message>
-    <message key="plugins.blocks.announcements.settings.h5">H5</message>
 </locale>

--- a/locale/de_DE/locale.xml
+++ b/locale/de_DE/locale.xml
@@ -12,7 +12,6 @@
     <message key="plugins.blocks.announcements.settings.right">Rechtsbündig</message>
     <message key="plugins.blocks.announcements.settings.center">Zentriert</message>
     <message key="plugins.blocks.announcements.settings.justify">Blocksatz</message>
-    <message key="plugins.blocks.announcements.headlineSize">HTML Typ der Überschrift</message>
     <message key="plugins.blocks.announcements.settings.h2">H2</message>
     <message key="plugins.blocks.announcements.settings.h3">H3</message>
     <message key="plugins.blocks.announcements.settings.h4">H4</message>

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -12,8 +12,4 @@
     <message key="plugins.blocks.announcements.settings.right">right</message>
     <message key="plugins.blocks.announcements.settings.center">center</message>
     <message key="plugins.blocks.announcements.settings.justify">justify</message>
-    <message key="plugins.blocks.announcements.settings.h2">H2</message>
-    <message key="plugins.blocks.announcements.settings.h3">H3</message>
-    <message key="plugins.blocks.announcements.settings.h4">H4</message>
-    <message key="plugins.blocks.announcements.settings.h5">H5</message>
 </locale>

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -12,7 +12,6 @@
     <message key="plugins.blocks.announcements.settings.right">right</message>
     <message key="plugins.blocks.announcements.settings.center">center</message>
     <message key="plugins.blocks.announcements.settings.justify">justify</message>
-    <message key="plugins.blocks.announcements.headlineSize">Headline HTML Type</message>
     <message key="plugins.blocks.announcements.settings.h2">H2</message>
     <message key="plugins.blocks.announcements.settings.h3">H3</message>
     <message key="plugins.blocks.announcements.settings.h4">H4</message>

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -5,8 +5,8 @@
     <message key="plugins.blocks.announcements.desc">This plugin provides sidebar announcements.</message>
     <message key="plugins.blocks.announcements.amount">Number of announcements</message>
     <message key="plugins.blocks.announcements.amount.desc">Expired announcements are not displayed by default.</message>
-    <message key="plugins.blocks.announcements.truncateNum">Content limitation (truncate)</message>
-    <message key="plugins.blocks.announcements.truncateNum.desc">If empty, the complete content of the short description is displayed. Otherwise, enter a number (e.g. 200).</message>
+    <message key="plugins.blocks.announcements.truncateNum">Character Limit</message>
+    <message key="plugins.blocks.announcements.truncateNum.desc">Limit how many characters to show from the announcement (e.g. 200). If empty, the full short description will be displayed.</message>
     <message key="plugins.blocks.announcements.textAlign">Content alignment</message>
     <message key="plugins.blocks.announcements.settings.left">left</message>
     <message key="plugins.blocks.announcements.settings.right">right</message>

--- a/templates/block.tpl
+++ b/templates/block.tpl
@@ -9,8 +9,8 @@
 							{$announcement->getLocalizedTitle()|escape}
 						</a>
 					</h3>
-					<time class="block_announcements_article_date" style="font-weight: bold;" datetime="{$announcement->getDatePosted()}">
-						{$announcement->getDatePosted()|date_format:"%e. %B %Y"}
+					<time class="block_announcements_article_date" datetime="{$announcement->getDatePosted()}">
+						<strong>{$announcement->getDatePosted()|date_format:$dateFormatLong}</strong>
 					</time>
 					<p class="block_announcements_article_content" style="text-align: {$textAlign};">
 						{assign var="ann_desc" value=$announcement->getLocalizedDescriptionShort()|strip_unsafe_html|regex_replace:"/(<p>|<p [^>]*>)/":""|regex_replace:"/(<\\/p>)/":"<br />"}

--- a/templates/block.tpl
+++ b/templates/block.tpl
@@ -1,9 +1,9 @@
-{if $announcementsSidebar && sizeof($announcementsSidebar)>0}
+{if !empty($announcementsSidebar)}
 	<div class="pkp_block block_announcements">
 		<h2 class="title">{translate key="announcement.announcements"}</h2>
 		<div class="content">
 			{foreach name=announcements from=$announcementsSidebar item=announcement}
-				<article class="block_announcements_article" {if !$smarty.foreach.announcements.last}style="padding-bottom: 15px; border-bottom: 1px solid gray;" {/if}>
+				<article class="block_announcements_article">
 					<h3 class="block_announcements_article_headline">
 						<a href="{url router=$smarty.const.ROUTE_PAGE page="announcement" op="view" path=$announcement->getId()}">
 							{$announcement->getLocalizedTitle()|escape}
@@ -24,5 +24,11 @@
 				</article>
 			{/foreach}
 		</div>
+		<style type="text/css">
+			.block_announcements_article:not(:last-child) {
+				padding-bottom: 1.5em;
+				border-bottom: 1px solid;
+			}
+		</style>
 	</div>
 {/if}

--- a/templates/block.tpl
+++ b/templates/block.tpl
@@ -1,27 +1,28 @@
 {if $announcementsSidebar && sizeof($announcementsSidebar)>0}
 	<div class="pkp_block block_announcements">
-		<span class="title">{translate key="announcement.announcements"}</span>
+		<h2 class="title">{translate key="announcement.announcements"}</h2>
 		<div class="content">
-            {foreach name=announcements from=$announcementsSidebar item=announcement}
+			{foreach name=announcements from=$announcementsSidebar item=announcement}
 				<article class="block_announcements_article" {if !$smarty.foreach.announcements.last}style="padding-bottom: 15px; border-bottom: 1px solid gray;" {/if}>
-					<a class="block_announcements_article_headline"
-					   href="{url router=$smarty.const.ROUTE_PAGE page="announcement" op="view" path=$announcement->getId()}">
-						<{$headlineSize}>{$announcement->getLocalizedTitle()|escape}</{$headlineSize}>
-					</a>
+					<h3 class="block_announcements_article_headline">
+						<a href="{url router=$smarty.const.ROUTE_PAGE page="announcement" op="view" path=$announcement->getId()}">
+							{$announcement->getLocalizedTitle()|escape}
+						</a>
+					</h3>
 					<time class="block_announcements_article_date" style="font-weight: bold;" datetime="{$announcement->getDatePosted()}">
-                        {$announcement->getDatePosted()|date_format:"%e. %B %Y"}
+						{$announcement->getDatePosted()|date_format:"%e. %B %Y"}
 					</time>
 					<p class="block_announcements_article_content" style="text-align: {$textAlign};">
-                        {assign var="ann_desc" value=$announcement->getLocalizedDescriptionShort()|strip_unsafe_html|regex_replace:"/(<p>|<p [^>]*>)/":""|regex_replace:"/(<\\/p>)/":"<br />"}
-                        {if $truncateNum}
-                            {assign var="truncateNum" value=$truncateNum|intval}
-                            {$ann_desc|truncate:$truncateNum}
-                        {else}
-                            {$ann_desc}
-                        {/if}
+						{assign var="ann_desc" value=$announcement->getLocalizedDescriptionShort()|strip_unsafe_html|regex_replace:"/(<p>|<p [^>]*>)/":""|regex_replace:"/(<\\/p>)/":"<br />"}
+						{if $truncateNum}
+							{assign var="truncateNum" value=$truncateNum|intval}
+							{$ann_desc|truncate:$truncateNum}
+						{else}
+							{$ann_desc}
+						{/if}
 					</p>
 				</article>
-            {/foreach}
+			{/foreach}
 		</div>
 	</div>
 {/if}

--- a/templates/block.tpl
+++ b/templates/block.tpl
@@ -12,15 +12,15 @@
 					<time class="block_announcements_article_date" datetime="{$announcement->getDatePosted()}">
 						<strong>{$announcement->getDatePosted()|date_format:$dateFormatLong}</strong>
 					</time>
-					<p class="block_announcements_article_content" style="text-align: {$textAlign};">
-						{assign var="ann_desc" value=$announcement->getLocalizedDescriptionShort()|strip_unsafe_html|regex_replace:"/(<p>|<p [^>]*>)/":""|regex_replace:"/(<\\/p>)/":"<br />"}
+					<div class="block_announcements_article_content" style="text-align: {$textAlign};">
+						{assign var="ann_desc" value=$announcement->getLocalizedDescriptionShort()|strip_unsafe_html}
 						{if $truncateNum}
 							{assign var="truncateNum" value=$truncateNum|intval}
 							{$ann_desc|truncate:$truncateNum}
 						{else}
 							{$ann_desc}
 						{/if}
-					</p>
+					</div>
 				</article>
 			{/foreach}
 		</div>

--- a/templates/settings.tpl
+++ b/templates/settings.tpl
@@ -21,9 +21,6 @@
         {fbvFormSection title="plugins.blocks.announcements.textAlign"}
             {fbvElement id="textAlign" type="select" from=$textAlignOptions selected=$textAlign}
         {/fbvFormSection}
-        {fbvFormSection title="plugins.blocks.announcements.headlineSize"}
-            {fbvElement id="headlineSize" type="select" from=$headlineSizeOptions selected=$headlineSize}
-        {/fbvFormSection}
     {/fbvFormArea}
     {fbvFormButtons submitText="common.save"}
 </form>


### PR DESCRIPTION
Looks great! The following are some recommended changes. We don't require them, but they are made in the interests of making this compatible with as many different journals and themes as possible.

1. I removed the headline size and fixed a `<h2>` for the whole block and `<h3>` for each announcement. This is the pattern that we are following for all blocks in response to an accessibility audit that we had done on the default theme. (See https://github.com/pkp/pkp-lib/issues/5176). In general, end-users should not override this because using the wrong heading can cause accessibility problems. So I think the option shouldn't be there.

2. I made some adjustments to the character limit text in English that I think will be clearer to non-technical users.

3. I moved the styles you had applied out of the `styles="..."` attribute and into a separate `<style>...<style>` block. This is because styles applied on the HTML element can not be overridden by a stylesheet. And for this reason, the styles would cause problems for themes that want to support your theme. I left the required styles in a `<style>...</style>` block, but I would strongly recommend that you get rid of this and move any styles that you personally want into your theme. In general, when plugins add styles, they often clash with themes and so whenever its possible to use no styles that is often the best approach. (I'm happy to add styles to the default theme to make sure this plugin looks great there.)

4. I left the text align setting in, but I would encourage you to remove it for the same reasons. Text alignment is something that should be handled at the theme level -- this block should sit alongside other blocks and not look any different to theme. Also, text alignment can differ for different languages, so in general we don't want to apply anything but the default text alignment. It's your plugin so if you have an important use-case for this setting, you can leave it in. But I'd really encourage you to remove it as an option.